### PR TITLE
Ubuntu installation documentation is missing a step

### DIFF
--- a/doc/simplecv.org/doc/installation.html
+++ b/doc/simplecv.org/doc/installation.html
@@ -64,6 +64,7 @@
 wget http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.2/OpenCV-2.2.0.tar.bz2
 bunzip2 OpenCV-2.2.0.tar.bz2
 tar xf OpenCV-2.2.0.tar
+cd OpenCV-2.2.0
 mkdir build
 cd build
 cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_PYTHON_SUPPORT=ON ..


### PR DESCRIPTION
Added 'cd' step after the tar and before the mkdir (shown with a + below)

tar xf OpenCV-2.2.0.tar
+cd OpenCV-2.2.0
mkdir build
