### PR TITLE
Filters added

### DIFF
--- a/SimpleCV/Display.py
+++ b/SimpleCV/Display.py
@@ -195,9 +195,6 @@ class Display:
         #   if one / both too small - center along axis
         #
         # this is getting a little long. Probably needs to be refactored. 
-        
-        # Tried to solve above mentioned points, don't know if my way is correct, but resizing is working.
-        # Also changed a line in ImageClass.py in show() function.
         wndwAR = float(self.resolution[0])/float(self.resolution[1])
         imgAR = float(img.width)/float(img.height)
         self.sourceresolution = img.size()
@@ -313,10 +310,9 @@ class Display:
                 cornerx = -1*x
                 cornery = -1*y
                 img = img.crop(x,y,targetw,targeth)
-
-                s = img.getPGSurface() # Show new resized image
+                s = img.getPGSurface()
             elif( img.width < self.resolution[0] and img.height >= self.resolution[1]): #height too big
-                crop along the y dimension and center along the x dimension
+                #crop along the y dimension and center along the x dimension
                 targetw = img.width
                 targeth = self.resolution[1]
                 targetx = (self.resolution[0]-img.width)/2
@@ -326,10 +322,9 @@ class Display:
                 cornerx = targetx
                 cornery = -1 * y
                 img = img.crop(x,y,targetw,targeth)
-
                 s = img.getPGSurface()
             elif( img.width > self.resolution[0] and img.height <= self.resolution[1]): #width too big
-                crop along the y dimension and center along the x dimension
+                #crop along the y dimension and center along the x dimension
                 targetw = self.resolution[0]
                 targeth = img.height
                 targetx = 0
@@ -339,7 +334,6 @@ class Display:
                 cornerx = -1 * x
                 cornery = targety
                 img = img.crop(x,y,targetw,targeth)
-  
                 s = img.getPGSurface()
             self.xoffset = cornerx
             self.yoffset = cornery


### PR DESCRIPTION
applyButterwothFilter(), applyGaussianFilter(), applyUnsharpMask() added. A 64x64 filter created. Resized it to fit image. And then applying DFT. Some test done regarding speed during run time. Examples are added. 

To increase speed during run-time, I have created a filter of small size,
iterated over it, resized it to image size, and apllied DFT on image using
resized filters.

Album link:  http://imgur.com/a/BhZRz
GitHub linl: https://github.com/jayrambhia/SimpleCVexamples
Results:
1.  Created a 32x32 image, and made a butterworth filter of appropriate
   diameter and order.
   converted it to SimpleCV.ImageClass.Image object.
   stretched it to 512x512 using resize()
   Applied dft on lenna using this filter.
   
   Highpass Butterworth filter:
       Filter Image:       http://i.imgur.com/OO5fi.png
       DFT image of lenna: http://i.imgur.com/PlIsw.png
   
   Lowpass Butterworth filter:
       Filter Image:       http://i.imgur.com/oQeTb.png
       DFT image of lenna: http://i.imgur.com/6RIq9.png
   
   Took average of 10 runs, 5 for highpass and 5 for lowpass.
       Average time to create filter, convert it to SimpleCV.ImageClass.Image object,
       resizing it, applying filter: 0.3116 sec
2.  Created a 64x64 image, and made a butterworth filter of appropriate
   diameter and order.
   converted it to SimpleCV.ImageClass.Image object.
   stretched it to 512x512 using resize()
   Applied dft on lenna using this filter.
   
   Highpass Butterworth filter:
       Filter Image:       http://i.imgur.com/Edve7.png
       DFT image of lenna: http://i.imgur.com/Y6e12.png
   
   Lowpass Butterworth filter:
       Filter Image:       http://i.imgur.com/aCzPM.png
       DFT image of lenna: http://i.imgur.com/bG1l9.png
   
   Took average of 10 runs, 5 for highpass and 5 for lowpass.
       Average time to create filter, convert it to SimpleCV.ImageClass.Image object,
       resizing it, applying filter: 0.3176 sec
3.  Created a 512x512 image, and made a butterworth filter of appropriate 
   diameter and order
   converted it to SimpleCV.ImageClass.Image object.
   Applied def on lenna using this filter.
   
   Highpass Butterworth filter:
       Filter Image:       http://i.imgur.com/iwgU9.png
       DFT image of lenna: http://i.imgur.com/sN0K1.png
   
   Lowpass Butterworth filter:
       Filter Image:       http://i.imgur.com/yg5HG.png
       DFT image of lenna: http://i.imgur.com/V7Ru2.png
   
   Took average of 20 runs, 10 for highpass and 10 for lowpass.
       Average time to create filter, convert it to SimpleCV.ImageClass.Image object,
       resizing it, applying filter: 0.8429 sec

Conclusion:
    Creating a small filter of appropriate diameter and order, and then resizing
    it is a good method to increase speed during run-time. But it's still not the right
    way. I have tried using it for images of size 1680x1050, and the average time is
    more than 2 secs.

Some Points:
    It seems to me that, converting filter (cv2.cv.iplimage type) to SimpleCV Image object,
    is taking some precious time. If you could allow one channel cv2.cv.iplimage as filter
    in applyDFTFilter(), I think it would save some time of coneverting filter to SimpleCV 
    Image object and then taking it's bitmapimage for DFT.
     I have also tried using cv.ReSize() on filter (cv2.cv.iplimage), it is saving some time,
    but again I have to convert it to SimpleCV Image for DFT.

I have added 64x64 filters, since there's not much significant difference in speed betwenn 32x32 filter and 64x64 filter, but for bigger images, a 64x64 filter would work better than a 32x32 filter.
