### PR TITLE
Ticket 222: quit() added to quit pygame instance

### DIFF
--- a/SimpleCV/Display.py
+++ b/SimpleCV/Display.py
@@ -687,3 +687,16 @@ class Display:
         if(y < 0 ):
             ry = 0   
         return (rx,ry)
+        
+    def quit(self):
+        """
+        quit the pygame instance
+
+        Example:
+        >>> img = Image("simplecv")
+        >>> d = img.show()
+        >>> time.sleep(5)
+        >>> d.quit()
+        """
+        pg.display.quit()
+        pg.quit()


### PR DESCRIPTION
http://sourceforge.net/p/simplecv/tickets/222/
I think this commit might be helpful for ticket 222. When I use simplecv shell, I am getting an error while trying to quit pygame display.
    error: video system not initialized

I have added a quit() function is Display class. And it seems to be working well. Please let me know if I am doing something wrong here.

Example:
i = Image("simplecv")
d = i.show()
time.sleep(3)
d.quit()
