### PR TITLE
updated JpegStreamReader to support header up to 55 characters in length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ SimpleCV/utils/*
 SimpleCV/utils/
 SimpleCV/tests/*.pkl
 *.ipynb
+*.komodoproject

--- a/SimpleCV/Camera.py
+++ b/SimpleCV/Camera.py
@@ -805,7 +805,7 @@ class JpegStreamReader(threading.Thread):
                 (header, length) = data.split(":")
                 length = int(length.strip())
                
-            if (re.search("JFIF", data, re.I) or re.search("\xff\xd8\xff\xdb", data) or len(data) > 50):
+            if (re.search("JFIF", data, re.I) or re.search("\xff\xd8\xff\xdb", data) or len(data) > 55):
                 # we have reached the start of the image 
                 buff = '' 
                 if length and length > len(data):


### PR DESCRIPTION
My camera, a DCS-932L, includes a Date header in the MJPEG header that exceeds current header limit of 50. I have updated the limit to 55.
