### PR TITLE
Hist function in simplecv shell

### DIFF
--- a/SimpleCV/Shell/Shell.py
+++ b/SimpleCV/Shell/Shell.py
@@ -72,7 +72,14 @@ def plot(arg):
   plt.plot(arg)
   plt.show()
 
-
+def hist(arg):
+  try:
+    import pylab
+  except:
+    logger.warning("pylab is not installed and required")
+    return
+  plot(pylab.hist(arg)[1])
+  
 def magic_clear(self, arg):
   shellclear()
 


### PR DESCRIPTION
Hi,
Hist(Histogram) function is working now. This will override the default magic hist function. This solves issue #128.
