### PR TITLE
Partial Support For OpenCV 2.4.0

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -6774,7 +6774,7 @@ class Image:
             self._mKPDescriptors = None
             
         if( self._mKeyPoints is None or self._mKPFlavor != flavor ):
-            if (!new_version):
+            if (not new_version):
                 if( flavor == "SURF" ):
                     surfer = cv2.SURF(thresh,_extended=highQuality,_upright=1) 
                     self._mKeyPoints,self._mKPDescriptors = surfer.detect(self.getGrayNumpy(),None,False)
@@ -6810,14 +6810,14 @@ class Image:
                     self._mKPFlavor = "STAR"
                     del starer
           
-            elif( new_version and flavour in ["ORB","FAST","STAR","SIFT","SURF","MSER","GFTT","HARRIS","Dense"] ):
-               FeatureDetector = cv2.FeatureDetector_create(flavour)
-               DescriptorExtractor = cv2.DescriptorExtractor_create(flavour)
+            elif( new_version and flavor in ["ORB","FAST","STAR","SIFT","SURF","MSER","GFTT","HARRIS","Dense"] ):
+               FeatureDetector = cv2.FeatureDetector_create(flavor)
+               DescriptorExtractor = cv2.DescriptorExtractor_create(flavor)
                self._mKeyPoints = FeatureDetector.detect(self.getGrayNumpy())
                self._mKeyPoints,self._mKPDescriptors = DescriptorExtractor.compute(self.getGrayNumpy(),self._mKeyPoints)
                if( len(self._mKPDescriptors) == 0 ):
                     return None, None     
-               self._mKPFlavor = flavour
+               self._mKPFlavor = flavor
 	       del FeatureDetector
 	    
 	    else:


### PR DESCRIPTION
I have cross checked the changes i have made in both the versions of OpenCV, i.e 2.4.0 as well as in 2.3.0 and it is working fine. 

Resolved Factors :
1) ORB feature detector added which will replace SURF for OpenCV ver 2.4.0 and greater.
2) CalcOpticalFlowBM had some problem with window parameter , it has been resolved with necessary modifications for block, shift ,spread variables.

Unresolved Issue :
1) FLANN support.
