### PR TITLE
Filename of the image retained 

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -2221,7 +2221,7 @@ class Image:
                   Idisplay.display(IPImage(filename=loc))
                   return
                 else:
-                  self.filename = "" 
+                  #self.filename = "" 
                   self.filehandle = fh
                   fh.writeFrame(saveimg)
 


### PR DESCRIPTION
There was a line in the display condition :

``` python
self.filename = ""
```

I have commented this.

Now the filename of the image object is retained after running 
the code as mentioned in #231.
