### PR TITLE
fix import PIL issue on Mac

### DIFF
--- a/SimpleCV/base.py
+++ b/SimpleCV/base.py
@@ -62,14 +62,16 @@ except ImportError:
 #optional libraries
 PIL_ENABLED = True
 try:
-    import Image as pil
-    from Image.GifImagePlugin import getheader, getdata
+    from PIL import Image as pil
+    from PIL import ImageFont as pilImageFont
+    from PIL import ImageDraw as pilImageDraw
+    from PIL import GifImagePlugin 
+    getheader = GifImagePlugin.getheader
+    getdata   = GifImagePlugin.getdata
 except ImportError:
     try:
-        import PIL.Image as pil
-        from PIL import ImageFont as pilImageFont
-        from PIL import ImageDraw as pilImageDraw
-        from PIL.GifImagePlugin import getheader, getdata
+        import Image as pil
+        from GifImagePlugin import getheader, getdata
     except ImportError:
         PIL_ENABLED = False
 


### PR DESCRIPTION
When I install PIL the  simplecv can't start.It's because the SimpleCV/base.py import PIL has some issue.I write a patch for that.so check it out.(only test in Mac OSX 10.8)
