### PR TITLE
Fixed bug in getLineScan() method

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -11603,7 +11603,7 @@ class Image:
               x is None and y is None):
 
             pts = self.bresenham_line(pt1,pt2)
-            retVal = LineScan([gray[p[1],p[0]] for p in pts])
+            retVal = LineScan([gray[p[0],p[1]] for p in pts])
             retVal.pointLoc = pts
             retVal.image = self
             


### PR DESCRIPTION
I found a small bug in the getLineScan() method when y is not None and the value of y exceeds the height of the image. It gave an error instead of logging a warning.

![Screenshot from 2012-12-24 23:35:54](https://f.cloud.github.com/assets/820105/29973/1622ecd4-4df7-11e2-9859-8cca4b39e024.png)

```
    elif( x is None and y is not None and pt1 is None and pt2 is None):
        if( y >= 0 and x < self.height):
            retVal = LineScan(gray[:,y])
            retVal.image = self
```

The problem was in the second line where x < self.height should actually be y < self.height

I am not sure but I think I found another problem when pt1 and pt2 are passed.

```
    pts = self.bresenham_line(pt1,pt2)
    retVal = LineScan([gray[p[1],p[0]] for p in pts])
    retVal.pointLoc = pts
    retVal.image = self
```

I think it should actually be gray[p[0]p[1]] instead of gray[p[1]p[0]].
