### PR TITLE
Sorted Keypoints

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -12030,6 +12030,8 @@ class Image:
         for i, dis in itertools.izip(idx, dist):
             if dis < quality:
                 sfs.append(KeyPoint(template, skp[i], sd, "SIFT"))
+            else:
+                break #since sorted
 
         idx, dist = self._getFLANNMatches(td, sd)
         dist = dist[:,0]/2500.0
@@ -12043,6 +12045,8 @@ class Image:
         for i, dis in itertools.izip(idx, dist):
             if dis < quality:
                 tfs.append(KeyPoint(template, tkp[i], td, "SIFT"))
+            else:
+                break
 
         return sfs, tfs
         


### PR DESCRIPTION
keypoints are sorted according to the distance so user can provide number of best matches to be drawn. There was also an indentation error(weird). solved it.
And used **~img**, got an error -> Image instance has no attribute '**invert**', so added it.

```
i=Image("kpimg.png")
i1=Image("kptemp.png")
img=i.drawSIFTKeyPointMatch(i1,width=2,num=10)
img.show()
```

![sift_match_num](https://f.cloud.github.com/assets/1256649/77745/546575f2-6157-11e2-9a6b-34b639e7a92c.png)

Invert:

```
img1 = ~img
img1.show()
```
