### PR TITLE
Broken matchSIFTKeyPoints(in OpenCV < 2.4.3) resolved

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -12103,7 +12103,12 @@ class Image:
         try:
             import cv2
         except ImportError:
-            logger.warning("OpenCV >= 2.3.0 required")
+            logger.warning("OpenCV >= 2.4.3 required")
+            return None
+        if not "2.4.3" in cv2.__version__:
+            # I don't know; they might roll out 2.4.3.2
+            logger.warning("OpenCV >= 2.4.3 required")
+            return None
         if template == None:
             return None
         detector = cv2.FeatureDetector_create("SIFT")

--- a/SimpleCV/tests/tests.py
+++ b/SimpleCV/tests/tests.py
@@ -3098,6 +3098,14 @@ def test_logicalXOR():
         assert False
         
 def test_matchSIFTKeyPoints():
+    try:
+        import cv2
+    except ImportError:
+        pass
+        return
+    if not "2.4.3" in cv2.__version__:
+        pass
+        return
     img = Image("lenna")
     skp, tkp =  img.matchSIFTKeyPoints(img)
     if len(skp) == len(tkp):


### PR DESCRIPTION
maychSIFTKeyPoints (function and tests) broke in OpenCV 2.3.1

---
##### ERROR: SimpleCV.tests.tests.test_matchSIFTKeyPoints

---

```
 Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose-1.1.2-py2.7.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/kscottz/SimpleCV/SimpleCV/tests/tests.py", line 3102, in test_matchSIFTKeyPoints
    skp, tkp =  img.matchSIFTKeyPoints(img)
  File "/home/kscottz/SimpleCV/SimpleCV/ImageClass.py", line 12109, in matchSIFTKeyPoints
    detector = cv2.FeatureDetector_create("SIFT")
AttributeError: 'module' object has no attribute 'FeatureDetector_create'
```
