### PR TITLE
turned getColor() into a classmethd

### DIFF
--- a/SimpleCV/Color.py
+++ b/SimpleCV/Color.py
@@ -118,7 +118,8 @@ class Color:
                 DEFAULT
                 ]
 
-    def getRandom(self):
+    @classmethod
+    def getRandom(cls):
         """
         **SUMMARY**
 
@@ -137,8 +138,8 @@ class Color:
         >>> img.show()
 
         """
-        r = random.randint(1, (len(self.colorlist) - 1))
-        return self.colorlist[r]
+        r = random.randint(1, (len(cls.colorlist) - 1))
+        return cls.colorlist[r]
 
     @classmethod
     def hsv(cls, tuple):


### PR DESCRIPTION
There was a bug in SimpleCV.Color.getRandom() where the documentation didn't match the actual code.

Specifically, the example in the docs made it seem like this method was a classmethod, when in reality the user first had to create an empty SimpleCV.Color instance and then call the getRandom() method on the instance.

I just turned getRandom() into a proper classmethod. I didn't have to alter the documentation, it was already in place ;)

With this change, older code will still work unaffected, but newer code can use the classmethod call.

Example usage:

``` python
import SimpleCV

# creating a random color
# old behaviour
dummy_color = SimpleCV.Color()
random_color = dummy_color.getRandom()
# new behaviour (old behaviour works as well)
random_color = SimpleCV.Color.getRandom()
```
