### PR TITLE
Fix SimpleCV for PIL 1.1.7 (at least)

### DIFF
--- a/SimpleCV/base.py
+++ b/SimpleCV/base.py
@@ -63,7 +63,7 @@ except ImportError:
 PIL_ENABLED = True
 try:
     import Image as pil
-    from Image.GifImagePlugin import getheader, getdata
+    from GifImagePlugin import getheader, getdata
 except ImportError:
     try:
         import PIL.Image as pil


### PR DESCRIPTION
In PIL 1.1.7 GifImagePlugin is importable from global scope, not from the Image namespace. To check, do:

    >>> import GifImagePlugin
