### PR TITLE
Select channel in setLineScan/getLineScan

### DIFF
--- a/SimpleCV/tests/tests.py
+++ b/SimpleCV/tests/tests.py
@@ -3031,11 +3031,11 @@ def test_LineScan():
         ls4 = ls3.fitToModel(aLine)
         ls4.getModelParameters(aLine)
     img = Image("lenna")
-    ls = img.getLineScan(x=128)
+    ls = img.getLineScan(x=128,channel=1)
     lsstuff(ls)
     ls = img.getLineScan(y=128)
     lsstuff(ls)
-    ls = img.getLineScan(pt1 = (0,0), pt2=(128,128))
+    ls = img.getLineScan(pt1 = (0,0), pt2=(128,128),channel=2)
     lsstuff(ls)
     pass
 


### PR DESCRIPTION
Added a channel select option in Image.getLineScan/Image.getLineScan functions. 

Now the user can work any color space and select any valid channel from an image and pull out a linescan. 

Example:

```
img = Image("lenna")
ls = img.getLineScan(x=200,channel=0)
for i in range(len(ls)):
    ls[i] = 0
img = img.replaceLineScan(ls)
img.show()
```

this code will select the Red channel and set it to zero in the image.
