### PR TITLE
Fixes to unintended RGB<->BGR colorspace inversions during ndarray conversions

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -3923,7 +3923,7 @@ class Image:
         :py:meth:`applyHLSCurve`
 
         """
-        tempMat = np.array(self.getMatrix()).copy()
+        tempMat = self.getNumpyCv2().copy() #FIXME is copy really needed?...maybe if format caching is used
         tempMat[:, :, 0] = np.take(bCurve.mCurve, tempMat[:, :, 0])
         tempMat[:, :, 1] = np.take(gCurve.mCurve, tempMat[:, :, 1])
         tempMat[:, :, 2] = np.take(rCurve.mCurve, tempMat[:, :, 2])


### PR DESCRIPTION
The expression `np.array(self.getMatrix())` where `self` is of type `Image` is a bug that causes an unintended colorspace inversion BGR->RGB (but the colorspace is invariant for RGB images).

Here is some code that exposes the bug, where `img0` should be equivalent to the `img1` but is not, violating the following identity transformations:

``` python
from SimpleCV import *
img0 = Image("lenna").toBGR()
img1 = Image(img0.getNumpyCv2().swapaxes(0,1))
img1.save("blue_lenna.png")
```

and this _opposite_ RGB->BGR inversion bug, likely caused by a short-sighted attempt to fix the previous bug:

``` python
from SimpleCV import *
img0 = Image("lenna").toRGB()
img1 = Image(img0.getNumpy())
img1.save("blue_lenna.png")
```

I recommend a series of such "invariant" transformation tests as part of a unit testing framework.

These patches make the following changes:
- Fixes BGR->RGB inversion in the `Image.getNumpyCv2` by forcing conversion to RGB Image before conversion to a numpy array. 
- Fixes the _opposite_ RGB->BGR inversion in the implementation of `Image.getNumpy`, it has been changed by removing backwards slicing of the 3rd dimension and forcing the preliminary RGB conversion.
- All instances of the aforementioned problematic expression in the file `ImageClass.py` have been replaced by calls to these amended methods.

![blue_lenna](https://f.cloud.github.com/assets/1470227/307128/979123a0-96b1-11e2-90b4-c62135fed1ee.png)
