### PR TITLE
findPeaks() implemented for LineScan

### DIFF
--- a/SimpleCV/LineScan.py
+++ b/SimpleCV/LineScan.py
@@ -1025,4 +1025,48 @@ class LineScan(list):
         retVal = LineScan(map(int,self.convolve(kernel)))
         retVal._update(self)
         return retVal
-                
+
+    def findPeaks(self, window = 30, delta = 3):
+        """
+        **SUMMARY**
+
+        Finds the peaks in a LineScan.
+
+        **PARAMETERS**
+
+        * *window* - the size of the window in which the peak
+         should have the highest value to be considered as a peak.
+         By default this is 15 as it gives appropriate results.
+         The lower this value the more the peaks are returned
+
+        * *delta* - the minimum difference between the peak and 
+        all elements in the window
+
+        **RETURNS**
+
+        A list of (peak position, peak value) tuples.
+
+        **EXAMPLE**
+
+        >>> ls = img.getLineScan(x=10)
+        >>> peaks = ls.findPeaks()
+        >>> print peaks
+        >>> peaks10 = ls.findPeaks(window=10)
+        >>> print peaks10
+        
+        """
+
+        maximum = -np.Inf
+        width = int(window/2.0)
+        peaks = []
+
+        for index,val in enumerate(self):
+            #peak found
+            if val > maximum:
+                maximum = val
+                maxpos = index
+            #checking whether peak satisfies window and delta conditions
+            if max( self[max(0, index-width):index+width])+delta< maximum:
+                peaks.append((maxpos, maximum))
+                maximum = -np.Inf
+        return peaks

--- a/SimpleCV/tests/tests.py
+++ b/SimpleCV/tests/tests.py
@@ -3485,9 +3485,18 @@ def test_getFREAKDescriptor():
     pass
 
 def test_grayPeaks():
-    i=Image('lenna')
-    peaks=i.grayPeaks()
-    if peaks==None:
+    i = Image('lenna')
+    peaks = i.grayPeaks()
+    if peaks == None:
+        assert False
+    else:
+        pass
+
+def test_findPeaks():
+    img = Image('lenna')
+    ls = img.getLineScan(x=150)
+    peaks = ls.findPeaks()
+    if peaks == None:
         assert False
     else:
         pass


### PR DESCRIPTION
I have implemented the findPeaks() method for LineScan objects.
This method returns the peaks in form of a list of (peak position, peak value) tuples.

EXAMPLE:

```
ls = img.getLineScan(x=150)
peaks = ls.findPeaks()
print peaks
"""
output:
[(78, 153),
(123, 127),
(202, 143),
(234, 140),
(288, 129),
(349, 175),
(402, 151),
(455, 166)]
"""
```
