### PR TITLE
Always check for the return value of cv.QueryFrame()

### DIFF
--- a/SimpleCV/Camera.py
+++ b/SimpleCV/Camera.py
@@ -705,7 +705,12 @@ class VirtualCamera(FrameSource):
             return img
 
         if (self.sourcetype == 'video'):
-            return Image(cv.QueryFrame(self.capture), self)
+            # cv.QueryFrame returns None if the video is finished
+            frame = cv.QueryFrame(self.capture)
+            if frame:
+                return Image(frame, self)
+            else:
+                return None
 
         if (self.sourcetype == 'directory'):
             img = self.findLastestImage(self.source, 'bmp')


### PR DESCRIPTION
When grabbing frames from a video file, we have to check
the return value of cv.QueryFrame() in order to understand
whether the video is ended or not. Currently, SimpleCV
gives an exception when the video is over. See issue #135
