### PR TITLE
Add leading zeros to filenames in Image.save()

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -2207,7 +2207,7 @@ class Image:
                     num.append(int(glob.re.findall('[0-9]+$',img[:-4])[-1]))
                 num.sort()
                 fnum = num[-1]+1
-                filename = glob.os.path.join(path,filename+str(fnum)+".png")
+                filename = glob.os.path.join(path,filename+("%07d" % fnum)+".png")
                 self._tempFiles.append((filename,cleanTemp))
                 self.save(self._tempFiles[-1][0])
                 return self._tempFiles[-1][0]


### PR DESCRIPTION
Add leading zeros to index suffix when saving
images in an ImageSet with Image.save(). This
should fix the sorting problem mentioned in #358
