### PR TITLE
Copy cv.QueryFrame() into freshly created image

### DIFF
--- a/SimpleCV/Camera.py
+++ b/SimpleCV/Camera.py
@@ -711,7 +711,9 @@ class VirtualCamera(FrameSource):
             # cv.QueryFrame returns None if the video is finished
             frame = cv.QueryFrame(self.capture)
             if frame:
-                return Image(frame, self)
+                img = cv.CreateImage(cv.GetSize(frame), cv.IPL_DEPTH_8U, 3)
+                cv.Copy(frame, img)
+                return Image(img, self)
             else:
                 return None
 


### PR DESCRIPTION
Due to every cv.QueryFrame() modifies the same memory area we have
to use cv.CreateImage() and copy our cv.QueryFrame() into it. This
should fix the issue #96.
