### PR TITLE
README: Add installation instructions for Fedora 18

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,6 +113,20 @@ Install using clone of SimpleCV repository
     cd SimpleCV/
     sudo python setup.py install
 
+<a id="fedora"></a>
+### Fedora 18
+Install with pip
+
+    sudo yum -y install python-ipython opencv-python scipy numpy pygame python-setuptools python-pip
+    sudo python-pip install https://github.com/sightmachine/SimpleCV/zipball/develop
+
+Install using clone of SimpleCV repository
+
+    sudo yum -y install python-ipython opencv-python scipy numpy pygame python-setuptools python-pip git
+    git clone https://github.com/sightmachine/SimpleCV.git
+    cd SimpleCV/
+    sudo python setup.py install
+
 <a id="macos">
 ### Mac OS X (10.6 and above)
 </a>


### PR DESCRIPTION
Hello!

I've been playing around with SimpleCV on a Fedora system and thought it would be cool to send back instructions for anybody wandering by. These are based off of the Ubuntu dependencies which aren't very different aside from a few packages.

I've done capturing from the camera, and have run some of the [image segmentation](http://examples.simplecv.org/en/latest/examples/segment.html) examples with success.

cheers
