### PR TITLE
fixed max function of image class

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -4674,7 +4674,7 @@ class Image:
         """
         newbitmap = self.getEmpty()
         if is_number(other):
-            cv.MaxS(self.getBitmap(), other.getBitmap(), newbitmap)
+            cv.MaxS(self.getBitmap(), other, newbitmap)
         else:
             cv.Max(self.getBitmap(), other.getBitmap(), newbitmap)
         return Image(newbitmap, colorSpace=self._colorSpace)


### PR DESCRIPTION
max() function can take the other argument as an image or a number and returns the max of self and other.
Even if we passed other as an integer, the function tried to call the bitmap of other which caused an error. 
