### PR TITLE
Fixes in minValue and maxValue

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -4674,7 +4674,7 @@ class Image:
         """
         newbitmap = self.getEmpty()
         if is_number(other):
-            cv.MaxS(self.getBitmap(), other.getBitmap(), newbitmap)
+            cv.MaxS(self.getBitmap(), other, newbitmap)
         else:
             cv.Max(self.getBitmap(), other.getBitmap(), newbitmap)
         return Image(newbitmap, colorSpace=self._colorSpace)
@@ -4697,7 +4697,7 @@ class Image:
         """
         newbitmap = self.getEmpty()
         if is_number(other):
-            cv.MaxS(self.getBitmap(), other.getBitmap(), newbitmap)
+            cv.MaxS(self.getBitmap(), other, newbitmap)
         else:
             cv.Max(self.getBitmap(), other.getBitmap(), newbitmap)
         return Image(newbitmap, colorSpace=self._colorSpace)


### PR DESCRIPTION
minValue and maxValue returned numpy.uint8 objects. This caused problems if you did something like:

```
i = Image('lenna')
mn = i.minValue()
new = i-mn
```

The **sub** function expects an integer or an image. When this passed value is not an integer it treats it as an image and tries to get its bitmap which causes a problem in this case, as it calls getBitmap() on a numpy.uint8 object.
This fixes this problem for minValue and maxValue functions

Similar bug was present in the max() and min() functions also. The functions called getBitmap on numbers, causing errors.
