### PR TITLE
EdgeSnap - fixing grayNumPy copy

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -13714,7 +13714,7 @@ class Image:
         """
 
 
-        edgeMap = self.getGrayNumpy()
+        edgeMap = np.copy(self.getGrayNumpy())
 
         #Size of the box around a point which is checked for edges.
         box = step*4


### PR DESCRIPTION
I wasn't copying gray matrix. I should have been because I modify it in the fucntion later. 
