### PR TITLE
Fix for Orange paths

### DIFF
--- a/SimpleCV/base.py
+++ b/SimpleCV/base.py
@@ -103,7 +103,11 @@ except ImportError:
 
 ORANGE_ENABLED = True
 try:
-    import orange
+    try:
+        import orange
+    except ImportError:
+        import Orange; import orange
+
     import orngTest #for cross validation
     import orngStat
     import orngEnsemble # for bagging / boosting


### PR DESCRIPTION
SimpleCV prompts this:

```
WARNING: I'm sorry, but you need the orange machine learning library
installed to use this
```

However orange library is installed, but system paths are not correctly set. Importing `Orange` with capital O, and then `orange` fixes the issue, so SimpleCV can use it. I know it's quite hacky.

Apparently this is due to a bug in orange installer (installed through pip install) in some Operating system (Ubuntu 12.04):
http://orange.biolab.si/forum/viewtopic.php?f=4&t=1500

Cheers
Miguel
