### PR TITLE
Fixing ColorCuve Issue

### DIFF
--- a/SimpleCV/Color.py
+++ b/SimpleCV/Color.py
@@ -346,6 +346,10 @@ class ColorCurve:
     least 4 point pairs.  Either of these must map in a 255x255 space.  The curve
     can then be used in the applyRGBCurve, applyHSVCurve, and
     applyInstensityCurve functions.
+    
+    Note:
+    The points should be in strictly increasing order of their first elements
+    (X-coordinates)
 
     **EXAMPLE**
 


### PR DESCRIPTION
Fixes #97 
#### The Code

``` python
im = Image('lenna')
curve = ColorCurve([[0,0],[127,0],[128,255],[255,255]])
plt.plot(curve.mCurve)
im.applyIntensityCurve(curve).show()
plt.show()
```
#### Before

![old_plot](https://f.cloud.github.com/assets/3823490/606730/b60a3702-cd31-11e2-9620-fdc107956960.png)
![old_curve](https://f.cloud.github.com/assets/3823490/606733/c16467a8-cd31-11e2-9e37-d63d9a3aa060.jpg)
#### Now

![new_plot](https://f.cloud.github.com/assets/3823490/606729/b55c3d0a-cd31-11e2-9a2f-0dd2b8c305a9.png)
![new_curve](https://f.cloud.github.com/assets/3823490/606732/c161bc06-cd31-11e2-9ea2-8bd2da0bd411.jpg)

The suddent change of values made the UnivariateSpline go berzerk. Restricting the curve between 0 and 255 fixes the problem.
UnivariateSpline expects `x` to be increasing, that's why the exact situation of the forum question can't be replicated. I have changed the docs to specify that.
