### PR TITLE
Fixed bug in drawSIFTKeyPointMatch.

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -12894,7 +12894,7 @@ class Image:
             tkp = tfs[i]
             pt_a = (int(tkp.y), int(tkp.x)+hdif)
             pt_b = (int(skp.y)+template.width, int(skp.x))
-            resultImg.drawLine(pt_a, pt_b, color=Color.getRandom(Color()),thickness=width)
+            resultImg.drawLine(pt_a, pt_b, color=Color.getRandom(),thickness=width)
         return resultImg
 
     def stegaEncode(self,message):


### PR DESCRIPTION
Color.getRandom() takes no arguments, but it was being passed a Color() instance instead.
