### PR TITLE
Fixes (float(__version__) > 0.11) crash for sklearn 0.13.x

### DIFF
--- a/SimpleCV/Features/Features.py
+++ b/SimpleCV/Features/Features.py
@@ -1116,7 +1116,11 @@ class FeatureSet(list):
             X.append(featureVector)
 
         if method == "kmeans":
-            if (float(__version__) > 0.11):
+            
+            # Ignore minor version numbers.
+            sklearn_version = re.search(r'\d+\.\d+', __version__).group()
+            
+            if (float(sklearn_version) > 0.11):
                 k_means = KMeans(init='random', n_clusters=k, n_init=10).fit(X)
             else:
                 k_means = KMeans(init='random', k=k, n_init=10).fit(X)


### PR DESCRIPTION
sklearn versions added second dot and broke the float test used on line 1119, for which this pull request offers a fix.
