### PR TITLE
Changes requirements from PIL to pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
-PIL
+pillow
 ipython
 svgwrite

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name="SimpleCV",
   license='BSD',
   packages = find_packages(exclude=['ez_setup']),
   zip_safe = False,
-  requires=['cv2','cv', 'numpy', 'scipy', 'pygame', 'pil', 'svgwrite'],
+  requires=['cv2','cv', 'numpy', 'scipy', 'pygame', 'pillow', 'svgwrite'],
   package_data  = { #DO NOT REMOVE, NEEDED TO LOAD INLINE FILES i = Image('simplecv')
             'SimpleCV': ['sampleimages/*',
                         'Features/HaarCascades/*',


### PR DESCRIPTION
As requested on #468, pillow has several advantages over PIL and this change
should enable getting simplecv to Fedora's package system.

I uninstalled PIL, installed pillow and had no problems whatsoever, but I can't
assure that'll be the case for everyone. Although nobody needs to actually do
that for now, it'd be nice if people with other OSs tried that and ran the tests,
making sure this transition is indeed as smooth as promised.

Notice that this commit has no changes on code whatsoever: We already import PIL
the way pillow is imported.

Closes #468
