### PR TITLE
Removed dependency on "frontend" module(depreceated) for ipython ver>1.0

### DIFF
--- a/SimpleCV/Shell/Shell.py
+++ b/SimpleCV/Shell/Shell.py
@@ -115,7 +115,10 @@ def setup_ipython():
     try:
         import IPython
         from IPython.config.loader import Config
-        from IPython.frontend.terminal.embed import InteractiveShellEmbed
+        if IPython.version_info[0]>=1:
+            from IPython.terminal.embed import InteractiveShellEmbed
+        else:
+            from IPython.frontend.terminal.embed import InteractiveShellEmbed
 
         cfg = Config()
         cfg.PromptManager.in_template = "SimpleCV:\\#> "


### PR DESCRIPTION
From ipython 1.0 changelog ( http://ipython.org/ipython-doc/rel-1.0.0/whatsnew/version1.0.html ):  

> We have removed the frontend subpackage, as it caused unnecessary depth. So what was IPython.frontend.qt is now IPython.qt, and so on.</quote>
