### PR TITLE
Fix for new package structure in iPython v.1.1.0

### DIFF
--- a/SimpleCV/Shell/Shell.py
+++ b/SimpleCV/Shell/Shell.py
@@ -172,8 +172,8 @@ def setup_plain():
 
 def run_notebook(mainArgs):
     """Run the ipython notebook server"""
-    from IPython.frontend.html.notebook import notebookapp
-    from IPython.frontend.html.notebook import kernelmanager
+    from IPython.html import notebookapp
+    from IPython.html.services.kernels import kernelmanager
 
     code = ""
     code += "from SimpleCV import *;"


### PR DESCRIPTION
Corrections that let run SimpleCV inside iPython notebook version greater than 1.0.0 - as they changed package structure that time.

(regarding html.notebook for and notebookapp and kernelmanager)

see http://ipython.org/ipython-doc/rel-1.0.0/whatsnew/version1.0.html
