### PR TITLE
Added findHOGFeatures()

### DIFF
--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -917,22 +917,19 @@ class Image:
         m=0
         angles = np.arctan2(Iy,Ix)
         magnit = ((Ix**2)+(Iy**2))**0.5
+        for m,n,i,j in itertools.product(xrange(n_divs), xrange(n_divs), xrange(cellx), xrange(celly)):
+            #grad value
+            grad = magnit[m*cellx + i, n*celly+j][0]
+            #normalized grad value
+            norm_grad = grad/img_area
+            #Orientation Angle
+            angle = angles[m*cellx + i, n*celly+j][0]  
+            #(-pi,pi) to (0, 2*pi)
+            if(angle < 0):
+                angle = angle+ 2*pi
+            nth_bin = floor(float(angle/BIN_RANGE))
+            HOG[((m*n_divs+n)*n_bins + int(nth_bin))] += norm_grad
 
-        for m in range(0, n_divs):
-            for n in range(0, n_divs):
-                for i in range(0,cellx):
-                    for j in range(0, celly):
-                        #grad value
-                        grad = magnit[m*cellx + i, n*celly+j][0]
-                        #normalized grad value
-                        norm_grad = grad/img_area
-                        #Orientation Angle
-                        angle = angles[m*cellx + i, n*celly+j][0]  
-                        #(-pi,pi) to (0, 2*pi)
-                        if(angle < 0):
-                            angle = angle+ 2*pi
-                        nth_bin = floor(float(angle/BIN_RANGE))
-                        HOG[((m*n_divs+n)*n_bins + int(nth_bin))] += norm_grad
         return HOG.transpose()
 
 


### PR DESCRIPTION
HOG(Histogram of Oriented Gradients) features are widely used in various Computer Vision and image processing for object detection. 

Usage 

``` python
I = Image("lena.jpg")
H1 = I.findHOGFeatures()
H2 = I.findHOGFeatures(2,6)
```

For sample image:
![lena_color](https://f.cloud.github.com/assets/748711/2023588/cbea9764-885d-11e3-8923-ab147052eeb3.gif)
It would return the hog descriptor:

```
>H1
array([[ 0.70799777,  0.31031786,  0.43538802,  0.7119953 ,  0.35283551,
         0.44640515,  1.39636142,  0.66822192,  0.9737663 ,  1.35927688,
         0.61152601,  1.03855733,  1.69911792,  0.62897737,  1.92188941,
         1.67472578,  0.63001834,  1.99064839,  0.84245818,  0.80247882,
         0.79771883,  0.65534026,  0.76592214,  0.7464986 ,  1.95349545,
         0.73081933,  1.0270115 ,  1.88424318,  0.86515135,  1.01216288,
         0.79783098,  0.63841941,  0.56898374,  0.72427718,  0.6168658 ,
         0.72017109,  0.89275505,  0.46247547,  0.58670203,  0.93734243,
         0.41994468,  0.51827528,  0.95650341,  0.39389738,  0.71125951,
         0.83805511,  0.4436618 ,  0.74813277,  0.97483522,  0.36429496,
         0.8730933 ,  0.93598927,  0.48391781,  0.61659925]])
```

```
>H2
array([[ 2.3547329 ,  1.24260293,  1.34765038,  2.16142711,  1.28855857,
         1.59244553,  3.73639567,  1.53089352,  3.16332987,  3.63308637,
         1.47675359,  3.25464767,  2.11491471,  1.1703252 ,  1.68901189,
         2.11247633,  1.32217436,  1.43717833,  2.09424087,  1.08864922,
         1.72708496,  1.89273196,  1.13458106,  1.58801289]])
```
