### PR TITLE
Add python-pip to Readme for Ubuntu

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ Install with pip
 
 Install using clone of SimpleCV repository
 
-    sudo apt-get install ipython python-opencv python-scipy python-numpy python-pygame python-setuptools git
+    sudo apt-get install ipython python-opencv python-scipy python-numpy python-pygame python-setuptools git python-pip
     git clone https://github.com/sightmachine/SimpleCV.git
     cd SimpleCV/
     sudo pip install -r requirements.txt


### PR DESCRIPTION
You have two guides for Ubuntu 12.04 installation. While in the first one you do notice the python-pip package, the second one does not (but it still uses the pip). So you need to install python-pip both ways.
