### PR TITLE
typo in README for tests

### DIFF
--- a/SimpleCV/tests/README
+++ b/SimpleCV/tests/README
@@ -12,7 +12,7 @@ To install nosetools you can either use:
 
 
 once these are installed, just run the command
-  nosetest tests.py
+  nosetests tests.py
 
 to run basic functionality test working.  You should get all OK checks
 if everything is fine and dandy. But you will get errors if something


### PR DESCRIPTION
CHANGED: the README file about tests.

the nosetest command is: nosetests instead of nosetest
