### PR TITLE
Display.checkEvents(): don't keep processing events on QUIT

### DIFF
--- a/SimpleCV/Display.py
+++ b/SimpleCV/Display.py
@@ -608,6 +608,7 @@ class Display:
             if event.type == pg.QUIT:
                 pg.quit()
                 self.done = True
+                return
             if event.type == pg.MOUSEMOTION:
                 self.mouseRawX = event.pos[0]
                 self.mouseRawY = event.pos[1]

--- a/SimpleCV/Display.py
+++ b/SimpleCV/Display.py
@@ -608,7 +608,7 @@ class Display:
             if event.type == pg.QUIT:
                 pg.quit()
                 self.done = True
-                return
+                return key
             if event.type == pg.MOUSEMOTION:
                 self.mouseRawX = event.pos[0]
                 self.mouseRawY = event.pos[1]


### PR DESCRIPTION
On my test setup, continuing to process events when the QUIT event is
received results in the following output on stderr:

```
ERROR:
Traceback (most recent call last):
  File "/Users/keunwoo/Documents/cvplay/ENV/lib/python2.7/site-packages/SimpleCV/examples/detection/barcode_reader.py", line 29, in <module>
    while display.isNotDone():
  File "/Users/keunwoo/Documents/cvplay/ENV/lib/python2.7/site-packages/SimpleCV/Display.py", line 689, in isNotDone
    return not self.isDone()
  File "/Users/keunwoo/Documents/cvplay/ENV/lib/python2.7/site-packages/SimpleCV/Display.py", line 667, in isDone
    self.checkEvents()
  File "/Users/keunwoo/Documents/cvplay/ENV/lib/python2.7/site-packages/SimpleCV/Display.py", line 630, in checkEvents
    self.pressed = pg.key.get_pressed()
error: video system not initialized
Cleaned up camera.
```

The error message appears to be benign, but it would be cleaner not to
print it; at a minimum, it is confusing/alarming for new users.

This commit is based on the answer here:

http://help.simplecv.org/question/1505/error-with-example-from-page-25/

I literally just unpacked and ran simplecv for the first time a few
minutes ago, so I don't know if this is a correct fix, but it does get
rid of the error message.  (Naively, it seems like you shouldn't be
processing additional events after quit, but I'm not familiar with the
pygame framework.)

If accepted, this fix should probably also be backported to the develop
branch.
