### PR TITLE
Fix sdist generation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.html *.js *.py *.jpg *.png *.xml *.pdf *.ttf

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,15 @@ setup(name="SimpleCV",
   license='BSD',
   packages = find_packages(exclude=['ez_setup']),
   zip_safe = False,
-  requires=['cv2','cv', 'numpy', 'scipy', 'pygame', 'pil', 'svgwrite'],
+  install_requires=[
+    'cv2',
+    'cv',
+    'numpy',
+    'scipy',
+    'pygame',
+    'pil',
+    'svgwrite'
+  ],
   package_data  = { #DO NOT REMOVE, NEEDED TO LOAD INLINE FILES i = Image('simplecv')
             'SimpleCV': ['sampleimages/*',
                         'Features/HaarCascades/*',


### PR DESCRIPTION
This PR implements two things:

It adds all assets to the `sdist` zips by defining all files to be included in `MANIFEST.in`. By doing so 

 1. won't have to create each release ZIP manually
 1. you may add SimpleCV to PyPI by running `python setup.py sdist upload` 
 1. Your users may install SimpleCV without using the URL by simply typing `pip install simplecv`

Also, I've fixed the `install_requires` keyword in `setup.py`. Before, the installation could not declare its dependencies properly, which in my case left `svgwrite` missing.