### PR TITLE
Inserted check for confusion.

### DIFF
--- a/SimpleCV/MachineLearning/NaiveBayesClassifier.py
+++ b/SimpleCV/MachineLearning/NaiveBayesClassifier.py
@@ -237,8 +237,9 @@ class NaiveBayesClassifier:
             print("Incorrect: "+str(bad))
             classes = self.mDataSetOrange.domain.classVar.values
             print "\t"+"\t".join(classes)
-            for className, classConfusions in zip(classes, confusion):
-                print ("%s" + ("\t%i" * len(classes))) % ((className, ) + tuple(classConfusions))
+            if confusion > 0:
+                for className, classConfusions in zip(classes, confusion):
+                    print ("%s" + ("\t%i" * len(classes))) % ((className, ) + tuple(classConfusions))
 
         return [good, bad, confusion]
 


### PR DESCRIPTION
Additionally, chances are the class names count is less than or equal to 2 which is causing the confusion to be 0 and subsequently to fail to meet the zip functions required iteration of a variable to zip.