### PR TITLE
Add the module svgwrite

### DIFF
--- a/doc/HOWTO-Install on RaspberryPi.rst
+++ b/doc/HOWTO-Install on RaspberryPi.rst
@@ -17,7 +17,8 @@ Installing SimpleCV on the Raspberry Pi
 ::
 
 	sudo apt-get install ipython python-opencv python-scipy python-numpy python-setuptools python-pip
-
+	sudo pip install svgwrite
+	
 4) SimpleCV should now be ready to install. Download SimpleCV from github 
    and install from the source.
 


### PR DESCRIPTION
It was required upon running the simplecv tool, and not mentioned in the guide. Added in as a pip install step here.