### PR TITLE
README.md changes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -171,9 +171,8 @@ Install using clone of SimpleCV repository
     cd SimpleCV/
     sudo python setup.py install
 
-<a id="macos">
+<a id="mac-os-x-106-and-above"></a>
 ### Mac OS X (10.6 and above)
-</a>
 
 **General OSX Overview**
 


### PR DESCRIPTION
In the SimpleCV Documentation, the anchor tag for MAC OSX was not working as the headline was contained inside the anchor tag. 