### PR TITLE
docs: Fix a few typos

### DIFF
--- a/SimpleCV/Camera.py
+++ b/SimpleCV/Camera.py
@@ -1954,11 +1954,11 @@ class StereoImage:
         **PARAMETERS**
 
         * *Q* - reprojection Matrix (disparity to depth matrix)
-        * *method* - Stereo Correspondonce method to be used.
+        * *method* - Stereo Correspondence method to be used.
                    - "BM" - Stereo BM
                    - "SGBM" - Stereo SGBM
         * *state* - dictionary corresponding to parameters of
-                    stereo correspondonce.
+                    stereo correspondence.
                     SADWindowSize - odd int
                     nDisparity - int
                     minDisparity  - int
@@ -2531,11 +2531,11 @@ class StereoCamera :
         * *leftIndex* - Index of left camera
         * *rightIndex* - Index of right camera
         * *Q* - reprojection Matrix (disparity to depth matrix)
-        * *method* - Stereo Correspondonce method to be used.
+        * *method* - Stereo Correspondence method to be used.
                    - "BM" - Stereo BM
                    - "SGBM" - Stereo SGBM
         * *state* - dictionary corresponding to parameters of
-                    stereo correspondonce.
+                    stereo correspondence.
                     SADWindowSize - odd int
                     nDisparity - int
                     minDisparity  - int

--- a/SimpleCV/Display.py
+++ b/SimpleCV/Display.py
@@ -330,7 +330,7 @@ class Display:
         """
         **SUMMARY**
 
-        Given two screen cooridnates return the bounding box in x,y,w,h format.
+        Given two screen coordinates return the bounding box in x,y,w,h format.
         This is helpful for drawing regions on the display.
 
         **RETURNS**

--- a/SimpleCV/Features/Features.py
+++ b/SimpleCV/Features/Features.py
@@ -1075,7 +1075,7 @@ class FeatureSet(list):
         **PARAMETERS**
         
         * *properties* - It should be a list with any combination of "color", "shape", "position". properties = ["color","position"]. properties = ["position","shape"]. properties = ["shape"]
-        * *method* - if method is "kmeans", it will cluster using K-Means algorithm, if the method is "hierarchical", no need to spicify the number of clusters
+        * *method* - if method is "kmeans", it will cluster using K-Means algorithm, if the method is "hierarchical", no need to specify the number of clusters
         * *k* - The number of clusters(kmeans).
         
 

--- a/SimpleCV/ImageClass.py
+++ b/SimpleCV/ImageClass.py
@@ -889,7 +889,7 @@ class Image:
 
         **PARAMETERS**
 
-        * *source* - The source of the image. This can be just about anything, a numpy arrray, a file name, a width and height
+        * *source* - The source of the image. This can be just about anything, a numpy array, a file name, a width and height
           tuple, a url. Certain strings such as "lenna" or "logo" are loaded automatically for quick testing.
 
         * *camera* - A camera to pull a live image.
@@ -13584,7 +13584,7 @@ class Image:
         for i in range(num_of_clusters ): #count the frequency of occurences for sorting
             xycounts = np.append(xycounts, len(np.where(xylabels == i)[-1]))
             
-        merged = np.msort(np.hstack((np.vstack(xycounts), xycentroids))) #sort based on occurence
+        merged = np.msort(np.hstack((np.vstack(xycounts), xycentroids))) #sort based on occurrence
         clusters = [c[1:] for c in merged] # strip out just the values ascending
         if order.lower() == 'dsc':
             clusters = clusters[::-1] #reverse if descending
@@ -14504,7 +14504,7 @@ class Image:
         """
         **SUMMARY**
 
-        Performs image normalization and yeilds a linearly normalized gray image.
+        Performs image normalization and yields a linearly normalized gray image.
         Also known as contrast strestching.
 
         see : http://en.wikipedia.org/wiki/Normalization_(image_processing)

--- a/SimpleCV/base.py
+++ b/SimpleCV/base.py
@@ -375,7 +375,7 @@ def system():
     Output of this function includes various informations related to system and library.
     
     Main purpose:
-    - While submiting a bug, report the output of this function
+    - While submitting a bug, report the output of this function
     - Checking the current version and later upgrading the library based on the output
     
     **RETURNS**

--- a/SimpleCV/examples/detection/CannyCam.py
+++ b/SimpleCV/examples/detection/CannyCam.py
@@ -2,7 +2,7 @@
 '''
 This example just takes an image, finds the edges, and draws them
 the threshold is used for the edge detection, if you adjust the
-max_threshold and threshhold_step values and run the program you will
+max_threshold and threshold_step values and run the program you will
 see it change over time
 '''
 print __doc__

--- a/scripts/install/win/OpenKinect/freenect-examples/demo_cv_thresh_sweep.py
+++ b/scripts/install/win/OpenKinect/freenect-examples/demo_cv_thresh_sweep.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Sweeps throught the depth image showing 100 range at a time"""
+"""Sweeps through the depth image showing 100 range at a time"""
 import freenect
 import cv
 import numpy as np


### PR DESCRIPTION
There are small typos in:
- SimpleCV/Camera.py
- SimpleCV/Display.py
- SimpleCV/Features/Features.py
- SimpleCV/ImageClass.py
- SimpleCV/base.py
- SimpleCV/examples/detection/CannyCam.py
- scripts/install/win/OpenKinect/freenect-examples/demo_cv_thresh_sweep.py

Fixes:
- Should read `correspondence` rather than `correspondonce`.
- Should read `yields` rather than `yeilds`.
- Should read `threshold` rather than `threshhold`.
- Should read `through` rather than `throught`.
- Should read `submitting` rather than `submiting`.
- Should read `specify` rather than `spicify`.
- Should read `occurrence` rather than `occurence`.
- Should read `coordinates` rather than `cooridnates`.
- Should read `array` rather than `arrray`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md